### PR TITLE
ユーザー詳細ページ(2)

### DIFF
--- a/app/assets/stylesheets/relationship.css
+++ b/app/assets/stylesheets/relationship.css
@@ -101,3 +101,22 @@
   height: calc(100vh - 150px);
   overflow: scroll;
 }
+
+.follow-list-header-lower-left a {
+  color: #999;
+}
+
+.follow-list-header-lower-left a:hover {
+  color: white;
+  background-color: #526f94;
+}
+
+.follower-list-header-lower-right a {
+  color: #253141;
+  border-bottom: 2px solid #253141;
+}
+
+.follower-list-header-lower-right a:hover {
+  color: white;
+  background-color: #526f94;
+}

--- a/app/assets/stylesheets/relationship.css
+++ b/app/assets/stylesheets/relationship.css
@@ -13,7 +13,7 @@
   font-size: smaller;
   padding: 5px 20px;
   border-radius: 20px;
-  width: 110px;
+  width: 120px;
 }
 
 .following-btn {
@@ -22,10 +22,20 @@
   border: 1px solid #38aef0;
 }
 
-.following-btn:hover {
+.following-button > .following-btn-hover {
+  display: none;
+  background-color: red;
+  color: white;
+  border: 1px solid red;
+}
+
+.following-button:hover .following-btn {
+  display: none;
+}
+
+.following-button:hover .following-btn-hover {
+  display: inline;
   cursor: pointer;
-  background-color: #6fbeec;
-  border: 1px solid #6fbeec;
 }
 
 .unfollow-btn {

--- a/app/assets/stylesheets/relationship.css
+++ b/app/assets/stylesheets/relationship.css
@@ -96,3 +96,8 @@
   color: white;
   background-color: #526f94;
 }
+
+.follow-list-main {
+  height: calc(100vh - 150px);
+  overflow: scroll;
+}

--- a/app/assets/stylesheets/relationship.css
+++ b/app/assets/stylesheets/relationship.css
@@ -40,19 +40,13 @@
   background-color:#ddf3ff;
 }
 
-.follow-number{
+.follow-number {
   display: flex;
-  justify-content: center;
-  margin-bottom: 10px;
 }
 
-.following{
+.following,
+.follower {
   margin-right:20px;
-}
-
-.following a, .follower a{
-  text-decoration: none;
-  color: black;
 }
 
 .follow-lists{

--- a/app/assets/stylesheets/relationship.css
+++ b/app/assets/stylesheets/relationship.css
@@ -71,7 +71,7 @@
 }
 
 .follow-list-header-upper-user {
-  font-size: larger;
+  font-size: 20px;
   font-weight: bold;
   line-height: 50px;
   padding: 0 20px;

--- a/app/assets/stylesheets/relationship.css
+++ b/app/assets/stylesheets/relationship.css
@@ -49,34 +49,50 @@
   margin-right:20px;
 }
 
-.follow-lists{
-  margin: 20px 0;
+.follow-list-header {
+  height: 100px;
+  background-color: #FAFAFA;
+  border-bottom: 5px solid #DDDDDD;
 }
 
-.follow-container{
-  padding: 0 160px;
-}
-
-.follow-list-title{
-  text-align: center;
-  font-size: 20px;
-  font-weight: bold;
-}
-
-.follow-list a{
+.follow-list-header a {
   text-decoration: none;
   color: black;
 }
 
-.follow-content{
+.follow-list-header-upper-user {
+  font-size: larger;
+  font-weight: bold;
+  line-height: 50px;
+  padding: 0 20px;
+}
+
+.follow-list-header-lower {
   display: flex;
-  padding: 10px 20px;
+  justify-content: space-around;
 }
 
-.follow-content-upper{
-  width: 85%;
+.follow-list-header-lower a {
+  display: inline-block;
+  padding: 5px 30px;
+  font-weight: bold;
 }
 
-.follow-nickname{
-  font-size: 20px;
+.following-list-header-lower-left a {
+  color: #253141;
+  border-bottom: 2px solid #253141;
+}
+
+.following-list-header-lower-left a:hover {
+  color: white;
+  background-color: #526f94;
+}
+
+.follow-list-header-lower-right a {
+  color: #999;
+}
+
+.follow-list-header-lower-right a:hover {
+  color: white;
+  background-color: #526f94;
 }

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -227,3 +227,8 @@
   color: white;
   background-color: #526f94;
 }
+
+.user-group-list-main {
+  height: calc(100vh - 150px);
+  overflow: scroll;
+}

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -232,3 +232,22 @@
   height: calc(100vh - 150px);
   overflow: scroll;
 }
+
+.owner-group-list-header-lower-left a {
+  color: #999;
+}
+
+.owner-group-list-header-lower-left a:hover {
+  color: white;
+  background-color: #526f94;
+}
+
+.owner-group-list-header-lower-right a {
+  color: #253141;
+  border-bottom: 2px solid #253141;
+}
+
+.owner-group-list-header-lower-right a:hover {
+  color: white;
+  background-color: #526f94;
+}

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -113,40 +113,46 @@
   font-size: 13px;
 }
 
-
-.user-show-container{
-  padding: 0 160px;
-  margin-bottom: 50px;
+.user-show-header {
+  padding: 10px 20px 0 20px;
+  height: 150px;
+  background-color: #FAFAFA;
+  border-bottom: 5px solid #DDDDDD;
 }
 
-.user-show-nickname{
-  text-align: center;
-  margin: 20px 0;
-  font-size: 30px;
+.user-show-header a {
+  text-decoration: none;
+  color: black;
+}
+
+.user-show-header-upper {
+  display: flex;
+  justify-content: space-between;
+}
+
+.user-show-header-upper-right-edit a {
+  display: inline-block;
+  font-size: smaller;
+  padding: 5px 20px;
+  border-radius: 20px;
+  color: darkgreen;
+  border: 1px solid darkgreen;
+}
+
+.user-show-header-upper-right-edit a:hover {
+  color: white;
+  background-color: darkgreen;
+  border: 1px solid darkgreen;
+}
+
+.user-show-nickname {
+  font-size: larger;
   font-weight: bold;
 }
 
-.user-show-button{
-  display: flex;
-  justify-content: center;
-  font-size: 20px;
-  margin-bottom: 20px;
-}
-
-.user-show-button a{
-  text-decoration: none;
-  color: white;
-}
-
-.user-show-edit{
-  background-color: darkgreen;
-  padding: 10px 20px;
-}
-
-.user-show-introduction{
-  font-size: 25px;
-  margin-bottom: 20px;
-  padding: 0 100px;
+.user-show-introduction {
+  height: 50px;
+  overflow: scroll;
 }
 
 .user-show-tweets-title{

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -175,31 +175,7 @@
   margin-right: 20px;
 }
 
-.user-show-tweets-title{
-  text-align: center;
-  font-size: 20px;
-}
-
-.user-show-group-name{
-  font-size: 18px;
-}
-
-.user-show-group-name a{
-  text-decoration: none;
-  color: black;
-}
-
-.user-show-tweet a{
-  text-decoration: none;
-}
-
-.user-show-tweet-content{
-  font-size: 20px;
-  color: black;
-  padding: 0 20px;
-}
-
-.user-show-tweet-date{
-  text-align: right;
-  color: gray;
+.user-show-main {
+  height: calc(100vh - 200px);
+  overflow: scroll;
 }

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -179,3 +179,51 @@
   height: calc(100vh - 200px);
   overflow: scroll;
 }
+
+.user-group-list-header {
+  height: 100px;
+  background-color: #FAFAFA;
+  border-bottom: 5px solid #DDDDDD;
+}
+
+.user-group-list-header a {
+  text-decoration: none;
+  color: black;
+}
+
+.user-group-list-header-upper {
+  font-size: 20px;
+  font-weight: bold;
+  line-height: 50px;
+  padding: 0 20px;
+}
+
+.user-group-list-header-lower {
+  display: flex;
+  justify-content: space-around;
+}
+
+.user-group-list-header-lower a {
+  display: inline-block;
+  padding: 5px 30px;
+  font-weight: bold;
+}
+
+.user-group-list-header-lower-left a {
+  color: #253141;
+  border-bottom: 2px solid #253141;
+}
+
+.user-group-list-header-lower-left a:hover {
+  color: white;
+  background-color: #526f94;
+}
+
+.user-group-list-header-lower-right a {
+  color: #999;
+}
+
+.user-group-list-header-lower-right a:hover {
+  color: white;
+  background-color: #526f94;
+}

--- a/app/assets/stylesheets/user.css
+++ b/app/assets/stylesheets/user.css
@@ -155,6 +155,26 @@
   overflow: scroll;
 }
 
+.user-show-header-lower,
+.user-show-header-lower-group {
+  display: flex;
+  justify-content: center;
+}
+
+.user-show-header-lower a {
+  color: #999;
+  font-weight: bold;
+}
+
+.user-show-header-lower a:hover {
+  color: black;
+  text-decoration: underline;
+}
+
+.user-show-header-lower-group-participation {
+  margin-right: 20px;
+}
+
 .user-show-tweets-title{
   text-align: center;
   font-size: 20px;

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -26,6 +26,7 @@ class RelationshipsController < ApplicationController
   end
 
   def follower
+    @groups = Group.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc").limit(20)
     @user = User.find(params[:id])
     @followers = @user.followers
   end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -20,6 +20,7 @@ class RelationshipsController < ApplicationController
   end
 
   def following
+    @groups = Group.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc").limit(20)
     @user = User.find(params[:id])
     @followings = @user.followings 
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update]
 
   def show
+    @groups = Group.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc").limit(20)
     @tweets = @user.tweets.order("created_at DESC")
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!, only: :edit
-  before_action :set_user, only: [:show, :edit, :update]
+  before_action :set_user, only: [:show, :edit, :update, :list]
 
   def show
     @groups = Group.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc").limit(20)
@@ -19,6 +19,11 @@ class UsersController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def list
+    @groups = Group.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc").limit(20)
+    @groupLists = @user.groups.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc")
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!, only: :edit
-  before_action :set_user, only: [:show, :edit, :update, :list]
+  before_action :set_user, only: [:show, :edit, :update, :list, :owner]
 
   def show
     @groups = Group.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc").limit(20)
@@ -24,6 +24,11 @@ class UsersController < ApplicationController
   def list
     @groups = Group.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc").limit(20)
     @groupLists = @user.groups.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc")
+  end
+
+  def owner
+    @groups = Group.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc").limit(20)
+    @groupOwners = @user.owned_groups.select("groups.*, COUNT(group_users.id) users_count").left_joins(:group_users).group("groups.id").order("users_count desc")
   end
 
   private

--- a/app/views/groups/_member_list.html.erb
+++ b/app/views/groups/_member_list.html.erb
@@ -1,0 +1,28 @@
+<div class="group-member-main-container">
+  <div class="group-member-main-upper">
+    <div class="group-member-main-upper-left"></div>
+    <div class="group-member-main-upper-right">
+      <% if user_signed_in? %>
+        <% unless current_user.id == user.id %>
+          <%= render partial: "/relationships/follow_button", locals: { user: user } %>
+        <% else %>
+          <div class="group-member-main-upper-right-edit">
+            <%= link_to(edit_user_path(user.id)) do %>
+              <i class="fa fa-wrench fa-fw"></i>アカウント編集
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+  <div class="group-member-main-lower">
+    <%= link_to(user_path(user.id)) do %>
+      <div class="group-member-user-nickname">
+        <%= user.nickname %>
+      </div>
+      <div class="group-member-user-introduction">
+        <%= user.introduction %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/groups/member.html.erb
+++ b/app/views/groups/member.html.erb
@@ -13,34 +13,7 @@
     </div>
     <div class="group-member-main">
       <% @users.each do |user| %>
-        <div class="group-member-main-container">
-          <div class="group-member-main-upper">
-            <div class="group-member-main-upper-left"></div>
-            <div class="group-member-main-upper-right">
-              <% if user_signed_in? %>
-                <% unless current_user.id == user.id %>
-                  <%= render partial: "/relationships/follow_button", locals: { user: user } %>
-                <% else %>
-                  <div class="group-member-main-upper-right-edit">
-                    <%= link_to(edit_user_path(user.id)) do %>
-                      <i class="fa fa-wrench fa-fw"></i>アカウント編集
-                    <% end %>
-                  </div>
-                <% end %>
-              <% end %>
-            </div>
-          </div>
-          <div class="group-member-main-lower">
-            <%= link_to(user_path(user.id)) do %>
-              <div class="group-member-user-nickname">
-                <%= user.nickname %>
-              </div>
-              <div class="group-member-user-introduction">
-                <%= user.introduction %>
-              </div>
-            <% end %>
-          </div>
-        </div>
+        <%= render partial: "member_list", locals: { user: user } %>
       <% end %>
     </div>
   </div>

--- a/app/views/relationships/_follow_button.html.erb
+++ b/app/views/relationships/_follow_button.html.erb
@@ -2,7 +2,10 @@
   <% if current_user.following?(user) %>
     <%= form_for(current_user.relationships.find_by(follow_id: user.id), html: { method: :delete }) do |f| %>
       <%= hidden_field_tag :follow_id, user.id %>
-      <%= f.submit 'フォロー中', class: 'follow-btn following-btn' %>
+      <div class="following-button">
+        <%= f.submit 'フォロー中', class: 'follow-btn following-btn' %>
+        <%= f.submit 'フォロー解除', class: 'follow-btn following-btn-hover' %>
+      </div>
     <% end %>
   <% else %>
     <%= form_for(current_user.relationships.build) do |f| %>

--- a/app/views/relationships/follower.html.erb
+++ b/app/views/relationships/follower.html.erb
@@ -1,13 +1,10 @@
-<div class="follow-lists">
-  <div class="follow-container">
-    <div class="follow-list-title">
-      <%= "#{@user.nickname}:フォロワー" %>
-      <hr>
-    </div>
-    <div class="follow-list">
-      <% @followers.each do |follower| %>
-        <%= render partial: "list", locals: { user: follower } %>
-      <% end %>
-    </div>
+<div class="wrapper">
+  <div class="left-bar">
+    <%= render "/tweets/left_bar" %>
+  </div>
+  <div class="main">
+  </div>
+  <div class="right-bar">
+    <%= render "/tweets/right_bar" %>
   </div>
 </div>

--- a/app/views/relationships/follower.html.erb
+++ b/app/views/relationships/follower.html.erb
@@ -18,6 +18,11 @@
         </div>
       </div>
     </div>
+    <div class="follow-list-main">
+      <% @followers.each do |follower| %>
+        <%= render partial: "/groups/member_list", locals: { user: follower } %>
+      <% end %>
+    </div>
   </div>
   <div class="right-bar">
     <%= render "/tweets/right_bar" %>

--- a/app/views/relationships/follower.html.erb
+++ b/app/views/relationships/follower.html.erb
@@ -3,6 +3,21 @@
     <%= render "/tweets/left_bar" %>
   </div>
   <div class="main">
+    <div class="follow-list-header">
+      <div class="follow-list-header-upper">
+        <div class="follow-list-header-upper-user">
+          <%= @user.nickname %>
+        </div>
+      </div>
+      <div class="follow-list-header-lower">
+        <div class="follow-list-header-lower-left">
+          <%= link_to "フォロー中", following_relationship_path(@user) %>
+        </div>
+        <div class="follower-list-header-lower-right">
+          <%= link_to "フォロワー", follower_relationship_path(@user) %>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="right-bar">
     <%= render "/tweets/right_bar" %>

--- a/app/views/relationships/following.html.erb
+++ b/app/views/relationships/following.html.erb
@@ -18,6 +18,11 @@
         </div>
       </div>
     </div>
+    <div class="follow-list-main">
+      <% @followings.each do |following| %>
+        <%= render partial: "/groups/member_list", locals: { user: following } %>
+      <% end %>
+    </div>
   </div>
   <div class="right-bar">
     <%= render "/tweets/right_bar" %>

--- a/app/views/relationships/following.html.erb
+++ b/app/views/relationships/following.html.erb
@@ -1,13 +1,10 @@
-<div class="follow-lists">
-  <div class="follow-container">
-    <div class="follow-list-title">
-      <%= "#{@user.nickname}:フォロー中" %>
-      <hr>
-    </div>
-    <div class="follow-list">
-      <% @followings.each do |following| %>
-        <%= render partial: "list", locals: { user: following } %>
-      <% end %>
-    </div>
+<div class="wrapper">
+  <div class="left-bar">
+    <%= render "/tweets/left_bar" %>
+  </div>
+  <div class="main">
+  </div>
+  <div class="right-bar">
+    <%= render "/tweets/right_bar" %>
   </div>
 </div>

--- a/app/views/relationships/following.html.erb
+++ b/app/views/relationships/following.html.erb
@@ -3,6 +3,21 @@
     <%= render "/tweets/left_bar" %>
   </div>
   <div class="main">
+    <div class="follow-list-header">
+      <div class="follow-list-header-upper">
+        <div class="follow-list-header-upper-user">
+          <%= @user.nickname %>
+        </div>
+      </div>
+      <div class="follow-list-header-lower">
+        <div class="following-list-header-lower-left">
+          <%= link_to "フォロー中", following_relationship_path(@user) %>
+        </div>
+        <div class="follow-list-header-lower-right">
+          <%= link_to "フォロワー", follower_relationship_path(@user) %>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="right-bar">
     <%= render "/tweets/right_bar" %>

--- a/app/views/tweets/_left_bar.html.erb
+++ b/app/views/tweets/_left_bar.html.erb
@@ -42,7 +42,7 @@
   <% if user_signed_in? %>
     <div class="left-bar-lower">
       <div class="left-bar-group-title">
-        <%= link_to root_path do %>
+        <%= link_to list_user_path(current_user.id) do %>
           <i class="fa fa-users fa-fw"></i>&nbsp;&nbsp;あなたのグループ
         <% end %>
       </div>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -3,6 +3,21 @@
     <%= render "/tweets/left_bar" %>
   </div>
   <div class="main">
+    <div class="user-group-list">
+      <div class="user-group-list-header">
+        <div class="user-group-list-header-upper">
+          <%= @user.nickname %>のグループ
+        </div>
+        <div class="user-group-list-header-lower">
+          <div class="user-group-list-header-lower-left">
+            <%= link_to "参加中", list_user_path(@user.id) %>
+          </div>
+          <div class="user-group-list-header-lower-right">
+            <%= link_to "オーナー", root_path %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="right-bar">
     <%= render "/tweets/right_bar" %>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -1,0 +1,10 @@
+<div class="wrapper">
+  <div class="left-bar">
+    <%= render "/tweets/left_bar" %>
+  </div>
+  <div class="main">
+  </div>
+  <div class="right-bar">
+    <%= render "/tweets/right_bar" %>
+  </div>
+</div>

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -17,6 +17,59 @@
           </div>
         </div>
       </div>
+      <div class="user-group-list-main">
+        <% @groupLists.each do |group| %>
+          <div class="group-list-main-container">
+            <div class="group-list-main-upper">
+              <div class="group-list-main-upper-left">
+                <div class="group-list-main-users-member">
+                  <%= link_to "#{group.users.length}参加中", member_group_path(group) %>
+                </div>
+              </div>
+              <div class="group-list-main-upper-right">
+                <% if user_signed_in? %>
+                  <% unless GroupUser.exists?(group_id: group.id, user_id: current_user.id) %>
+                    <div class="group-list-main-no-participation">
+                      <%= link_to '参　加', join_group_path(group) %>
+                    </div>
+                  <% else %>
+                    <div class="group-list-main-participation">
+                      <%= link_to '参加中', group_tweets_path(group) %>
+                    </div>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+            <div class="group-list-main-center">
+              <%= link_to(group_path(group.id)) do %>
+                <div class="group-list-main-group-name">
+                  <%= group.name%>
+                </div>
+                <div class="group-list-main-group-content">
+                  <%= group.content %>
+                </div>
+              <% end %>
+            </div>
+            <div class="group-list-main-lower">
+                <%= link_to(user_path(group.user_id)) do %>
+                  <div class="group-list-main-lower-left">
+                      <div class="group-list-main-group-owner-icon">
+                        <i class="fa fa-user-shield fa-fw"></i>
+                      </div>
+                      <div class="group-list-main-group-owner-name">
+                        <%= group.user.nickname %>
+                      </div>
+                  </div>
+                <% end %>
+              <div class="group-list-main-lower-right">
+                <div class="group-list-main-group-birthday">
+                  <i class="fa fa-history fa-fw"></i><%= l group.created_at %>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
   <div class="right-bar">

--- a/app/views/users/list.html.erb
+++ b/app/views/users/list.html.erb
@@ -13,7 +13,7 @@
             <%= link_to "参加中", list_user_path(@user.id) %>
           </div>
           <div class="user-group-list-header-lower-right">
-            <%= link_to "オーナー", root_path %>
+            <%= link_to "オーナー", owner_user_path(@user.id) %>
           </div>
         </div>
       </div>

--- a/app/views/users/owner.html.erb
+++ b/app/views/users/owner.html.erb
@@ -3,6 +3,21 @@
     <%= render "/tweets/left_bar" %>
   </div>
   <div class="main">
+    <div class="user-group-list">
+      <div class="user-group-list-header">
+        <div class="user-group-list-header-upper">
+          <%= @user.nickname %>のグループ
+        </div>
+        <div class="user-group-list-header-lower">
+          <div class="owner-group-list-header-lower-left">
+            <%= link_to "参加中", list_user_path(@user.id) %>
+          </div>
+          <div class="owner-group-list-header-lower-right">
+            <%= link_to "オーナー", owner_user_path(@user.id) %>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="right-bar">
     <%= render "/tweets/right_bar" %>

--- a/app/views/users/owner.html.erb
+++ b/app/views/users/owner.html.erb
@@ -17,6 +17,59 @@
           </div>
         </div>
       </div>
+      <div class="user-group-list-main">
+        <% @groupOwners.each do |group| %>
+          <div class="group-list-main-container">
+            <div class="group-list-main-upper">
+              <div class="group-list-main-upper-left">
+                <div class="group-list-main-users-member">
+                  <%= link_to "#{group.users.length}参加中", member_group_path(group) %>
+                </div>
+              </div>
+              <div class="group-list-main-upper-right">
+                <% if user_signed_in? %>
+                  <% unless GroupUser.exists?(group_id: group.id, user_id: current_user.id) %>
+                    <div class="group-list-main-no-participation">
+                      <%= link_to '参　加', join_group_path(group) %>
+                    </div>
+                  <% else %>
+                    <div class="group-list-main-participation">
+                      <%= link_to '参加中', group_tweets_path(group) %>
+                    </div>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+            <div class="group-list-main-center">
+              <%= link_to(group_path(group.id)) do %>
+                <div class="group-list-main-group-name">
+                  <%= group.name%>
+                </div>
+                <div class="group-list-main-group-content">
+                  <%= group.content %>
+                </div>
+              <% end %>
+            </div>
+            <div class="group-list-main-lower">
+                <%= link_to(user_path(group.user_id)) do %>
+                  <div class="group-list-main-lower-left">
+                      <div class="group-list-main-group-owner-icon">
+                        <i class="fa fa-user-shield fa-fw"></i>
+                      </div>
+                      <div class="group-list-main-group-owner-name">
+                        <%= group.user.nickname %>
+                      </div>
+                  </div>
+                <% end %>
+              <div class="group-list-main-lower-right">
+                <div class="group-list-main-group-birthday">
+                  <i class="fa fa-history fa-fw"></i><%= l group.created_at %>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
   <div class="right-bar">

--- a/app/views/users/owner.html.erb
+++ b/app/views/users/owner.html.erb
@@ -1,0 +1,10 @@
+<div class="wrapper">
+  <div class="left-bar">
+    <%= render "/tweets/left_bar" %>
+  </div>
+  <div class="main">
+  </div>
+  <div class="right-bar">
+    <%= render "/tweets/right_bar" %>
+  </div>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,46 +1,10 @@
-<div class="user-show-page">
-  <div class="user-show-container">
-    <div class="user-show-nickname">
-      <%= @user.nickname %>
-    </div>
-    <% if user_signed_in? %>
-      <%= render partial: "/relationships/follow_button", locals: { user: @user} %>
-    <% end %>
-    <div class="user-show-button">
-      <% if user_signed_in? && current_user.id == @user.id %>
-        <%= link_to 'アカウント編集', edit_user_path(@user.id), class: "user-show-edit" %>
-      <% end %>
-    </div>
-    <div class="user-show-introduction">
-      <%= @user.introduction %>
-    </div>
-    <%= render partial: "/relationships/follow_number" %>
-    <div class="user-show-tweets">
-      <div class="user-show-tweets-title">
-        ＜<%= @user.nickname %>のツイート＞
-      <hr>
-      </div>
-      <div class="user-show-tweet">
-        <% @tweets.each do |tweet| %>
-          <div class="user-show-tweet-upper">
-            <div class="user-show-group-name">
-              in: <%= link_to tweet.group.name, group_path(tweet.group.id) %>
-            </div>
-          </div>
-          <%= link_to(group_tweet_path(tweet.group.id, tweet.id), class: "user-show-tweet-lower") do %>
-            <div class="user-show-tweet-content">
-              <%= tweet.content %>
-            </div>
-            <div class="user-show-tweet-date">
-              <%= l tweet.created_at %>
-            </div>
-            <div class="user-show-tweet-image">
-              <%= image_tag tweet.image.variant(resize: '300x300') if tweet.image.attached? %>
-            </div>
-          <% end %>
-          <hr>
-        <% end %>
-      </div>
-    </div>
+<div class="wrapper">
+  <div class="left-bar">
+    <%= render "/tweets/left_bar" %>
+  </div>
+  <div class="main">
+  </div>
+  <div class="right-bar">
+    <%= render "/tweets/right_bar" %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -3,6 +3,29 @@
     <%= render "/tweets/left_bar" %>
   </div>
   <div class="main">
+    <div class="user-show-header">
+      <div class="user-show-header-upper">
+        <div class="user-show-header-upper-left"></div>
+        <div class="user-show-header-upper-right">
+          <% if user_signed_in? %>
+            <%= render partial: "/relationships/follow_button", locals: { user: @user } %>
+          <% end %>
+          <% if user_signed_in? && current_user.id == @user.id %>
+            <div class="user-show-header-upper-right-edit">
+              <%= link_to(edit_user_path(@user.id)) do %>
+                <i class="fa fa-wrench fa-fw"></i>アカウントを編集
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="user-show-nickname">
+        <%= @user.nickname %>
+      </div>
+      <div class="user-show-introduction">
+        <%= @user.introduction %>
+      </div>
+    </div>
   </div>
   <div class="right-bar">
     <%= render "/tweets/right_bar" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,6 +25,19 @@
       <div class="user-show-introduction">
         <%= @user.introduction %>
       </div>
+      <div class="user-show-header-lower">
+        <div class="user-show-header-lower-follow-member">
+          <%= render partial: "/relationships/follow_number" %>
+        </div>
+        <div class="user-show-header-lower-group">
+          <div class="user-show-header-lower-group-participation">
+            <%= link_to "#{@user.groups.length}グループ", root_path %>
+          </div>
+          <div class="user-show-header-lower-group-owner">
+            <%= link_to "#{@user.owned_groups.length}オーナー", root_path %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div class="right-bar">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,7 +31,7 @@
         </div>
         <div class="user-show-header-lower-group">
           <div class="user-show-header-lower-group-participation">
-            <%= link_to "#{@user.groups.length}グループ", root_path %>
+            <%= link_to "#{@user.groups.length}グループ", list_user_path(@user.id) %>
           </div>
           <div class="user-show-header-lower-group-owner">
             <%= link_to "#{@user.owned_groups.length}オーナー", root_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -34,7 +34,7 @@
             <%= link_to "#{@user.groups.length}グループ", list_user_path(@user.id) %>
           </div>
           <div class="user-show-header-lower-group-owner">
-            <%= link_to "#{@user.owned_groups.length}オーナー", root_path %>
+            <%= link_to "#{@user.owned_groups.length}オーナー", owner_user_path(@user.id) %>
           </div>
         </div>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,6 +39,9 @@
         </div>
       </div>
     </div>
+    <div class="user-show-main">
+      <%= render partial: '/tweets/tweet', collection: @tweets %>
+    </div>
   </div>
   <div class="right-bar">
     <%= render "/tweets/right_bar" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,11 @@ Rails.application.routes.draw do
     end
     resources :tweets
   end
-  resources :users, only: [:show, :edit, :update]
+  resources :users, only: [:show, :edit, :update] do
+    member do
+      get :list
+    end
+  end
   resources :relationships, only: [:index, :create, :destroy] do
     member do
       get :following

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :users, only: [:show, :edit, :update] do
     member do
       get :list
+      get :owner
     end
   end
   resources :relationships, only: [:index, :create, :destroy] do


### PR DESCRIPTION
# What
ユーザー詳細ページのリニューアル（left-barとright-barの追加）
所属グループ一覧ページとオーナーグループ一覧ページの追加

# Why
各ユーザーの所属グループと作成したグループの2つのページへ遷移できるようにすることで、好きなユーザーと同じグループに参加しやすいようにするため