### PR TITLE
ツイート投稿機能(2)

### DIFF
--- a/app/assets/stylesheets/tweets.css
+++ b/app/assets/stylesheets/tweets.css
@@ -240,24 +240,55 @@
   margin-right: 10px;
 }
 
-.form-input{
+.tweet-form {
+  width: 750px;
+  margin: 50px auto 0;
+  height: calc(100vh - 50px);
+  overflow: scroll;
+  background-color: #FAFAFA;
+  padding-bottom: 15px;
+}
+
+.tweet-form-container {
+  padding: 0 100px;
+}
+
+.tweet-form-wrapper {
+  margin-top: 30px;
+  padding: 10px;
+  border: 1px solid #253141;
+  border-radius: 20px;
+  background-color: white;
+}
+
+.tweet-form-upper-input {
+  width: 100%;
+  height: 180px;
+  padding: 5px;
+  border: none;
+}
+
+.tweet-form-lower {
+  padding-top: 15px;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
 }
 
-.form-tweet{
-  width: 50vw;
-  height: 100px;
-  margin-top: 20px;
+.tweet-form-lower-left-icon,
+.tweet-form-submit-btn {
+  border: 1px solid #253141;
+  background-color: #253141;
+  padding: 5px 15px;
+  border-radius: 20px;
+  font-size: large;
+  color: white;
 }
 
-.tweet-form{
-  display: flex;
-  justify-content: space-around;
-}
-
-.tweet-form-right{
-  margin-top: 15px;
+.tweet-form-lower-left-icon:hover,
+.tweet-form-submit-btn:hover {
+  cursor: pointer;
+  background-color: #526f94;
+  border: 1px solid #526f94;
 }
 
 .tweet-show-container {

--- a/app/assets/stylesheets/tweets.css
+++ b/app/assets/stylesheets/tweets.css
@@ -291,6 +291,11 @@
   border: 1px solid #526f94;
 }
 
+.input-text-count {
+  height: 30px;
+  text-align: right;
+}
+
 .tweet-show-container {
   padding-top: 10px;
   height: calc(100vh - 50px);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,6 +10,7 @@ require("@rails/activestorage").start()
 require("channels")
 require('jquery')
 require('./preview')
+require('./count')
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ require("@rails/ujs").start()
 //require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
+require('jquery')
 require('./preview')
 
 

--- a/app/javascript/packs/count.js
+++ b/app/javascript/packs/count.js
@@ -1,0 +1,21 @@
+if (document.URL.match( "tweets/new" ) || document.URL.match(/groups\/\d+\/tweets\/\d+\/edit/)) {
+  $(function(){
+    var MAX = 400
+    $('.input-text').on('keyup', function(){
+      var len = textLength($(this).val());
+      var color = len > MAX ? "red" : ""
+      $(".input-text-count").css("color", color);
+       $('.input-text-count').text(MAX - len);
+    });
+  })
+  
+  var regexp = /[\x01-\x7E\u{FF65}-\u{FF9F}]/mu;
+  function textLength(text){
+    var count = 0;
+    for(i = 0; i < text.length; i++){
+      var ch = text[i];
+      count += regexp.test(new String(ch)) ? 1 : 2;
+    }
+    return count
+  }  
+}

--- a/app/models/length_with_wide_char_validator.rb
+++ b/app/models/length_with_wide_char_validator.rb
@@ -1,0 +1,10 @@
+class LengthWithWideCharValidator < ActiveModel::EachValidator
+  def validate_each(object, attribute, value)
+    value = value.gsub(/\r\n/,"\n")
+    count = 0 
+    value.split(//).each do |v| 
+      v.bytesize > 1 ? count += 2 : count += 1
+    end 
+    object.errors[attribute] << (options[:content] || "is too long (maximum is %d characters)" % options[:maximum]) if count > options[:maximum]
+  end 
+end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -3,7 +3,8 @@ class Tweet < ApplicationRecord
   belongs_to :user
   has_one_attached :image
 
-  validates :content, presence: true, unless: :was_attached?
+  validates :content, presence: true, unless: :was_attached?,
+                      length_with_wide_char: { maximum: 400 }
 
   def was_attached?
     self.image.attached?

--- a/app/views/tweets/_tweet.html.erb
+++ b/app/views/tweets/_tweet.html.erb
@@ -16,7 +16,7 @@
     <div class="tweet-lower">
       <%= link_to group_tweet_path(tweet.group, tweet.id) do %> 
         <div class="tweet-content">
-          <%= tweet.content %>
+          <%= safe_join(tweet.content.split("\n"),tag(:br)) %>
           <%= image_tag tweet.image, class: 'tweet-image' if tweet.image.attached? %>
         </div>
       <% end %>

--- a/app/views/tweets/edit.html.erb
+++ b/app/views/tweets/edit.html.erb
@@ -1,22 +1,27 @@
-<%= form_with model: [@group, @tweet], local: true do |f| %>
-  <div class="form-input">
-    <%= f.text_area :content, class:'form-tweet', placeholder:'type a tweet' %>
-  </div>
-  <div class="tweet-form">
-    <div class="tweet-form-left"></div>
-    <div class="tweet-form-right">
-      <label class="form-image">
-        <span class="image-file">画像</span>
-        <%= f.file_field :image, class: 'hidden' %>
-      </label>
+<div class="tweet-form">
+  <%= form_with model: [@group, @tweet], local: true do |f| %>
+    <div class="tweet-form-container">
+      <div class="tweet-form-wrapper">
+        <div class="tweet-form-upper">
+          <%= f.text_area :content, class: "tweet-form-upper-input input-text", placeholder: '何を伝える？', autofocus: true %>
+        </div>
+        <div class="input-text-count"></div>
+        <div id="image-list"></div>
+          <%= image_tag @tweet.image if @tweet.image.attached? %>
+        <div class="tweet-form-lower">
+          <label class="tweet-form-lower-left">
+            <div class="tweet-form-lower-left-icon">
+              <span class="camera-icon"><i class="fa fa-camera-retro fa-fw"></i></span>
+              <%= f.file_field :image, class: 'hidden' %>
+            </div>
+          </label>
+          <div class="tweet-form-right">
+            <div class="tweet-form-submit">
+              <%= f.submit '編集する', class: "tweet-form-submit-btn" %>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-  <div id="image-list"></div>
-    <%= image_tag @tweet.image if @tweet.image.attached? %>
-  <div class="tweet-form">
-    <div class="tweet-form-left"></div>
-    <div class="tweet-form-right">
-      <%= f.submit '更新する', class:'form-submit' %>
-    </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -1,21 +1,25 @@
-<%= form_with model: [@group, @tweet], local: true do |f| %>
-  <div class="form-input">
-    <%= f.text_area :content, class:'form-tweet', placeholder:'type a tweet' %>
-  </div>
-  <div class="tweet-form">
-    <div class="tweet-form-left"></div>
-    <div class="tweet-form-right">
-      <label class="form-image">
-        <span class="image-file">画像</span>
-        <%= f.file_field :image, class: 'hidden' %>
-      </label>
+<div class="tweet-form">
+  <%= form_with model: [@group, @tweet], local: true do |f| %>
+    <div class="tweet-form-container">
+      <div class="tweet-form-wrapper">
+        <div class="tweet-form-upper">
+          <%= f.text_area :content, class: "tweet-form-upper-input", placeholder: '何を伝える？', autofocus: true %>
+        </div>
+        <div id="image-list"></div>
+        <div class="tweet-form-lower">
+          <label class="tweet-form-lower-left">
+            <div class="tweet-form-lower-left-icon">
+              <span class="camera-icon"><i class="fa fa-camera-retro fa-fw"></i></span>
+              <%= f.file_field :image, class: 'hidden' %>
+            </div>
+          </label>
+          <div class="tweet-form-right">
+            <div class="tweet-form-submit">
+              <%= f.submit 'ツイート', class: "tweet-form-submit-btn" %>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-  <div id="image-list"></div>
-  <div class="tweet-form">
-    <div class="tweet-form-left"></div>
-    <div class="tweet-form-right">
-      <%= f.submit '投稿する', class:'form-submit' %>
-    </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -3,8 +3,9 @@
     <div class="tweet-form-container">
       <div class="tweet-form-wrapper">
         <div class="tweet-form-upper">
-          <%= f.text_area :content, class: "tweet-form-upper-input", placeholder: '何を伝える？', autofocus: true %>
+          <%= f.text_area :content, class: "tweet-form-upper-input input-text", placeholder: '何を伝える？', autofocus: true %>
         </div>
+        <div class="input-text-count"></div>
         <div id="image-list"></div>
         <div class="tweet-form-lower">
           <label class="tweet-form-lower-left">

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -29,7 +29,7 @@
           <%= link_to @group.name, group_path(@group) %>
         </div>
         <div class="tweet-show-lower-content">
-          <%= @tweet.content %>
+          <%= safe_join(@tweet.content.split("\n"),tag(:br)) %>
           <%= image_tag @tweet.image, class: "tweet-show-lower-image" if @tweet.image.attached? %>
         </div>
         <div class="tweet-show-lower-date">

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery'
+    })
+)
+
 module.exports = environment

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@rails/activestorage": "^6.0.0-alpha",
     "@rails/ujs": "^6.0.0-alpha",
     "@rails/webpacker": "4.3.0",
+    "jquery": "^3.5.1",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4036,6 +4036,11 @@ jest-worker@^25.4.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.8:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.6.4.tgz#f4e686c5de1ea1f867dbcad3d46d969428df98c4"


### PR DESCRIPTION
# What
ツイート投稿ページと編集ページのリニューアル
文字数カウントを表示（全角は2文字、その他は1文字扱いに設定）

# Why
全角は2文字、その他は1文字扱いにすることで、日本語で投稿しても他言語で投稿しても、最大文字量を同じぐらいにする。
文字数カウントを表示することで、ユーザーが決められた文字数の範囲内で入力しやすくする。